### PR TITLE
Hotfix: Fixed root cause of random crashes (use after free)

### DIFF
--- a/TGEngine/TGEngine.cpp
+++ b/TGEngine/TGEngine.cpp
@@ -2,6 +2,7 @@
 #include "gamecontent/Light.hpp"
 #include "pipeline/window/Window.hpp"
 #include "pipeline/buffer/UniformBuffer.hpp"
+#include "io/Resource.hpp"
 
 using namespace std;
 using namespace tge::tex;
@@ -9,6 +10,7 @@ using namespace tge::gmc;
 using namespace tge::pip;
 using namespace tge::buf;
 using namespace tge::win;
+using namespace tge::io;
 
 VertexBuffer vertexBuffer;
 IndexBuffer indexBuffer;
@@ -132,6 +134,8 @@ void startTGEngine() {
 	destroyRenderPass();
 	destroyDepthTest();
 	destroyColorResouce();
+	destroyDescriptor();
+	destroyResource();
 	destroyDevice();
 	destroyWindows();
 	destroyInstance();

--- a/TGEngine/io/Resource.hpp
+++ b/TGEngine/io/Resource.hpp
@@ -14,8 +14,10 @@ namespace tge::io {
 
     struct Map {
         tge::tex::Sampler sampler;
-        tge::tex::Texture* textures;
+        std::vector<tge::tex::Texture> textures;
     };
+
+    extern Map currentMap;
 
     /*
      * This loads a map from a resource file
@@ -23,6 +25,11 @@ namespace tge::io {
      * https://troblecodings.com/fileformat.html
      * it automatically creates all ressources
      */
-    void loadResourceFile(const char* name, Map* map);
+    void loadResourceFile(const char* name);
+
+    /*
+     * This will destroy all vulkan tide ressources of the map
+     */
+    void destroyResource();
 
 }

--- a/TGEngine/pipeline/Descriptors.cpp
+++ b/TGEngine/pipeline/Descriptors.cpp
@@ -2,6 +2,8 @@
 
 VkPipelineLayout pipelineLayout;
 VkDescriptorSet mainDescriptorSets[3];
+VkDescriptorSetLayout descriptorSetLayout[2];
+VkDescriptorPool descriptorPool;
 
 void initDescriptors() {
 	VkDescriptorPoolSize* sizes = new VkDescriptorPoolSize[3];
@@ -22,7 +24,6 @@ void initDescriptors() {
 	descriptorPoolCreateInfo.poolSizeCount = 3;
 	descriptorPoolCreateInfo.pPoolSizes = sizes;
 
-	VkDescriptorPool descriptorPool;
 	CHECKFAIL(vkCreateDescriptorPool(device, &descriptorPoolCreateInfo, nullptr, &descriptorPool));
 
 	VkDescriptorSetLayoutBinding descriptorSetLayoutBindingTransform;
@@ -65,7 +66,6 @@ void initDescriptors() {
 	descriptorSetLayoutCreateInfoTextures.bindingCount = 3;
 	descriptorSetLayoutCreateInfoTextures.pBindings = descriptorSetLayoutBindingTextures;
 
-	VkDescriptorSetLayout descriptorSetLayout[2];
 	CHECKFAIL(vkCreateDescriptorSetLayout(device, &descriptorSetLayoutCreateInfoTextures, nullptr, descriptorSetLayout));
 	CHECKFAIL(vkCreateDescriptorSetLayout(device, &descriptorSetLayoutCreateInfoTransform, nullptr, &descriptorSetLayout[1]));
 
@@ -101,4 +101,13 @@ void initDescriptors() {
 	descriptorSetAllocateInfo.pSetLayouts = setLayouts;
 
 	CHECKFAIL(vkAllocateDescriptorSets(device, &descriptorSetAllocateInfo, mainDescriptorSets));
+}
+
+void destroyDescriptor() {
+	vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
+
+	vkDestroyDescriptorSetLayout(device, descriptorSetLayout[0], nullptr);
+	vkDestroyDescriptorSetLayout(device, descriptorSetLayout[1], nullptr);
+
+	vkDestroyDescriptorPool(device, descriptorPool, nullptr);
 }

--- a/TGEngine/pipeline/Descriptors.hpp
+++ b/TGEngine/pipeline/Descriptors.hpp
@@ -15,6 +15,6 @@ extern VkDescriptorPool descriptorPool;
 void initDescriptors();
 
 /*
- * This will cleanup the descriptor systems (Pool, Memory, Layouts ...)
+ * This will clean up the descriptor systems (Pool, Memory, Layouts ...)
  */
 void destroyDescriptor();

--- a/TGEngine/pipeline/Descriptors.hpp
+++ b/TGEngine/pipeline/Descriptors.hpp
@@ -6,8 +6,15 @@
 
 extern VkPipelineLayout pipelineLayout;
 extern VkDescriptorSet mainDescriptorSets[3];
+extern VkDescriptorSetLayout descriptorSetLayout[2];
+extern VkDescriptorPool descriptorPool;
 
 /*
  * This initialiazes the descriptor systems (Pool, Memory, Layouts ...)
  */
 void initDescriptors();
+
+/*
+ * This will cleanup the descriptor systems (Pool, Memory, Layouts ...)
+ */
+void destroyDescriptor();

--- a/TGEngine/pipeline/buffer/Texturebuffer.cpp
+++ b/TGEngine/pipeline/buffer/Texturebuffer.cpp
@@ -176,6 +176,14 @@ namespace tge::tex {
 		vkUpdateDescriptorSets(device, 1, &descwrite, 0, nullptr);
 	}
 
+	void destroyTexture(Texture* texture, uint32_t size) {
+		for (uint32_t i = 0; i < size; i++) {
+			vkDestroyImageView(device, texture[i].view, nullptr);
+			vkDestroyImage(device, texture[i].image, nullptr);
+			vkFreeMemory(device, texture[i].imagememory, nullptr);
+		}
+	}
+
 	void createSampler(SamplerInputInfo loaded, Sampler* sampler) {
 		// TODO Validation checks
 
@@ -218,6 +226,10 @@ namespace tge::tex {
 		descwrite.pBufferInfo = nullptr;
 		descwrite.pTexelBufferView = nullptr;
 		vkUpdateDescriptorSets(device, 1, &descwrite, 0, nullptr);
+	}
+
+	void destroySampler(Sampler sampler) {
+		vkDestroySampler(device, sampler, nullptr);
 	}
 
 }

--- a/TGEngine/pipeline/buffer/Texturebuffer.hpp
+++ b/TGEngine/pipeline/buffer/Texturebuffer.hpp
@@ -29,7 +29,6 @@ namespace tge::tex {
 	};
 
 	struct Texture {
-		uint32_t       id;
 		VkImage        image;
 		VkImageView    view;
 		VkDeviceMemory imagememory;
@@ -48,5 +47,9 @@ namespace tge::tex {
 
 	void createSampler(SamplerInputInfo input, Sampler* sampler);
 
+	void destroySampler(Sampler sampler);
+
 	void createTextures(TextureInputInfo* input, uint32_t size, Texture* output, uint32_t offset = 0);
+
+	void destroyTexture(Texture* texture, uint32_t size);
 }


### PR DESCRIPTION
The branch was not intended for this purpose so please do NOT delete it. This is a hotfix for an issue that was present during cleanup with O2 optimization appearing completely random. Turned out to be a life time issue with use after free, which in 50% of the cases overwrote the memory because it was freed somehow? For further details view the comment on the backlog on >43